### PR TITLE
Cleaned up the is_installed logic

### DIFF
--- a/library/yum.py
+++ b/library/yum.py
@@ -105,7 +105,7 @@ module = AnsibleModule(
 
 
 def is_installed(name):
-    rc, _, _ = module.run_command(['rpmquery', '--quiet', name])
+    rc, _, _ = module.run_command(['rpmquery', '--whatprovides', name])
     return rc == 0
 
 


### PR DESCRIPTION
There are times where packages are outdated and yum decides to
install a newer version.  This accounts for those cases.

For example: python-pip would install python2-pip if exists, yet
the module would error and report python-pip was not installed.